### PR TITLE
Hotfix

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -432,6 +432,9 @@ class Client implements ClientInterface
         }
 
         $iterator = new RecursiveArrayIterator($data);
+	    
+	//reset iterator array
+        $this->dirs = [];
 
         return $this->traversalDir($iterator);
     }


### PR DESCRIPTION
This fix will help to reset the array storing data generated by the iterator. In the current version you would call the listSubdirs('/',true) method first and than you would call listSubdirs('/',false) but the output would still be as the output of $client->listSubdirs('/',true).